### PR TITLE
add GetSeUserByName, fallback to failsafe context in GetDefaultContextWithLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Common SELinux package used across the container ecosystem.
 
+## Teleport Fork
+
+This fork exists to add finding the correct SELinux user mapping from a Linux user and reading the `failsafe_context` file in `GetDefaultContextWithLevel`. This is required for Teleport SSH's SELinux support.
+
+This fork may be archived when the equivalent functionality exists upstream.
+
 ## Usage
 
 Prior to v1.8.0, the `selinux` build tag had to be used to enable selinux functionality for compiling consumers of this project.

--- a/go-selinux/selinux.go
+++ b/go-selinux/selinux.go
@@ -305,11 +305,19 @@ func DisableSecOpt() []string {
 	return []string{"disable"}
 }
 
+// GetSeUserByName retrieves the SELinux username and security level for a given
+// Linux username. The username and security level is based on the
+// /etc/selinux/{SELINUXTYPE}/seusers file.
+func GetSeUserByName(username string) (seUser string, level string, err error) {
+	return getSeUserByName(username)
+}
+
 // GetDefaultContextWithLevel gets a single context for the specified SELinux user
 // identity that is reachable from the specified scon context. The context is based
 // on the per-user /etc/selinux/{SELINUXTYPE}/contexts/users/<username> if it exists,
 // and falls back to the global /etc/selinux/{SELINUXTYPE}/contexts/default_contexts
-// file.
+// file and finally the global /etc/selinux/{SELINUXTYPE}/contexts/failsafe_context
+// file if no match can be found anywhere else.
 func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
 	return getDefaultContextWithLevel(user, level, scon)
 }

--- a/go-selinux/selinux_linux_test.go
+++ b/go-selinux/selinux_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -580,6 +581,143 @@ func TestGlbLub(t *testing.T) {
 	}
 }
 
+func TestGetSeUser(t *testing.T) {
+	lookupGroup := func(string) (*user.Group, error) {
+		return &user.Group{
+			Gid:  "42",
+			Name: "group",
+		}, nil
+	}
+
+	tests := []struct {
+		name        string
+		username    string
+		gids        []string
+		seUserBuf   string
+		seUser      string
+		level       string
+		expectedErr string
+	}{
+		{
+			name:      "one entry match",
+			username:  "bob",
+			seUserBuf: "bob:staff_u:s0",
+			seUser:    "staff_u",
+			level:     "s0",
+		},
+		{
+			name:      "match with no level",
+			username:  "bob",
+			seUserBuf: "bob:staff_u",
+			seUser:    "staff_u",
+		},
+		{
+			name:     "match",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+bob:staff_u:s0-s15:c0.c255`,
+			seUser: "staff_u",
+			level:  "s0-s15:c0.c255",
+		},
+		{
+			name:     "match with comment",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+# foobar
+root:root:s0-s15:c0.c255
+bob:staff_u:s0-s15:c0.c255 #baz`,
+			seUser: "staff_u",
+			level:  "s0-s15:c0.c255",
+		},
+		{
+			name:     "no match",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255`,
+			expectedErr: `could not find SELinux user for "bob" login`,
+		},
+		{
+			name:     "group match",
+			username: "bob",
+			gids:     []string{"42"},
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+%group:staff_u:s0`,
+			seUser: "staff_u",
+			level:  "s0",
+		},
+		{
+			name:     "no group match",
+			username: "bob",
+			gids:     []string{"99"},
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+%group:staff_u:s0`,
+			expectedErr: `could not find SELinux user for "bob" login`,
+		},
+		{
+			name:     "malformed line",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+foobar
+bob:staff_u:s0-s15:c0.c255`,
+			expectedErr: "line 3: malformed line",
+		},
+		{
+			name:     "empty user",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+:seuser_u
+bob:staff_u:s0-s15:c0.c255`,
+			expectedErr: "line 3: user_id or group_id is empty",
+		},
+		{
+			name:     "empty seuser",
+			username: "bob",
+			seUserBuf: `
+system_u:system_u:s0-s15:c0.c255
+root:root:s0-s15:c0.c255
+user::s0
+bob:staff_u:s0-s15:c0.c255`,
+			expectedErr: "line 3: seuser_id is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			r := bytes.NewBufferString(tt.seUserBuf)
+			seUser, level, err := getSeUserFromReader(tt.username, tt.gids, r, lookupGroup)
+			if tt.expectedErr != "" {
+				if err == nil {
+					t.Fatal("expected an error but got nil")
+				} else if err.Error() != tt.expectedErr {
+					t.Fatalf("got error: %q but expected %q", err.Error(), tt.expectedErr)
+				}
+			} else if tt.expectedErr == "" && err != nil {
+				t.Fatalf("err should not exist but is: %v", err)
+			}
+
+			if seUser != tt.seUser {
+				t.Fatalf("got seUser: %q but expected %q", seUser, tt.seUser)
+			}
+			if level != tt.level {
+				t.Fatalf("got level: %q but expected %q", level, tt.level)
+			}
+		})
+	}
+}
+
 func TestContextWithLevel(t *testing.T) {
 	want := "bob:sysadm_r:sysadm_t:SystemLow-SystemHigh"
 
@@ -587,6 +725,7 @@ func TestContextWithLevel(t *testing.T) {
 foo_r:foo_t:s0     sysadm_r:sysadm_t:s0
 staff_r:staff_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 `
+	goodFailsafeBuff := "unconfined_r:unconfined_t:s0"
 
 	verifier := func(con string) error {
 		if con != want {
@@ -597,7 +736,7 @@ staff_r:staff_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 	}
 
 	tests := []struct {
-		name, userBuff, defaultBuff string
+		name, userBuff, defaultBuff, failsafeBuff string
 	}{
 		{
 			name: "match exists in user context file",
@@ -606,7 +745,8 @@ foo_r:foo_t:s0     sysadm_r:sysadm_t:s0
 
 staff_r:staff_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 `,
-			defaultBuff: goodDefaultBuff,
+			defaultBuff:  goodDefaultBuff,
+			failsafeBuff: goodFailsafeBuff,
 		},
 		{
 			name: "match exists in default context file, but not in user file",
@@ -614,7 +754,8 @@ staff_r:staff_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 foo_r:foo_t:s0     sysadm_r:sysadm_t:s0
 fake_r:fake_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 `,
-			defaultBuff: goodDefaultBuff,
+			defaultBuff:  goodDefaultBuff,
+			failsafeBuff: goodFailsafeBuff,
 		},
 	}
 
@@ -648,18 +789,27 @@ fake_r:fake_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 		dne_r:dne_t:s0                 baz_r:baz_t:s0   sysadm_r:sysadm_t:s0
 		`
 		c := defaultSECtx{
-			user:       "bob",
-			level:      "SystemLow-SystemHigh",
-			scon:       "system_u:staff_r:staff_t:s0",
-			userRdr:    bytes.NewBufferString(badUserBuff),
-			defaultRdr: bytes.NewBufferString(badDefaultBuff),
-			verifier:   verifier,
+			user:        "bob",
+			level:       "SystemLow-SystemHigh",
+			scon:        "system_u:staff_r:staff_t:s0",
+			userRdr:     bytes.NewBufferString(badUserBuff),
+			defaultRdr:  bytes.NewBufferString(badDefaultBuff),
+			failsafeRdr: bytes.NewBufferString(goodFailsafeBuff),
+			verifier: func(s string) error {
+				return nil
+			},
 		}
 
-		_, err := getDefaultContextFromReaders(&c)
-		if err == nil {
-			t.Fatalf("err was expected")
+		got, err := getDefaultContextFromReaders(&c)
+		if err != nil {
+			t.Fatalf("err should not exist but is: %v", err)
 		}
+
+		const want string = "bob:unconfined_r:unconfined_t:SystemLow-SystemHigh"
+		if got != want {
+			t.Fatalf("got context: %q but expected %q", got, want)
+		}
+
 	})
 }
 

--- a/go-selinux/selinux_stub.go
+++ b/go-selinux/selinux_stub.go
@@ -146,6 +146,10 @@ func dupSecOpt(string) ([]string, error) {
 	return nil, nil
 }
 
+func getSeUserByName(string) (string, string, error) {
+	return "", "", nil
+}
+
 func getDefaultContextWithLevel(string, string, string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
Ported `getseuserbyname` (https://github.com/SELinuxProject/selinux/blob/main/libselinux/src/seusers.c#L188) to Go, and added `failsafe_context` parsing to `GetDefaultContextWithLevel` as that's what libselinux's `get_default_context_with_level` does (https://github.com/SELinuxProject/selinux/blob/main/libselinux/src/get_context_list.c#L488).

`getseuserbyname` reads the `seusers` file (https://www.man7.org/linux/man-pages/man5/seusers.5.html) to find the SELinux user and the MLS level for a given Linux user.

`get_default_context_with_level` takes a SELinux user, MLS level, and an SELinux context (combination of SELinux user, role, domain, and MLS level, in many cases this context is the context of the caller) and returns the SELinux context that should be used when creating processes as a certain Linux user.

`get_default_context_with_level` attempts to find a suitable context for the specific SELinux user that was passed first, then searches in the list of global context mappings if no match was found, and finally just returns the failsafe context if no match was found anywhere else. `GetDefaultContextWithLevel` previously returned an error if no context could be found for the SELinux user or globally.

Man page for `failsafe_context`: https://www.man7.org/linux//man-pages/man5/failsafe_context.5.html